### PR TITLE
Make file system tests easier to implement

### DIFF
--- a/connection_testcases.json
+++ b/connection_testcases.json
@@ -98,7 +98,7 @@
       "homedir": "/Users/edgedb",
       "files": {
         "/Users/edgedb/test/edgedb.toml": "",
-        "/Users/edgedb/Library/Application Support/edgedb/projects/test-bea4557cb17f02c484b4e7f8ea93fc168ecd28d4": {
+        "/Users/edgedb/Library/Application Support/edgedb/projects/test-${HASH}": {
           "instance-name": "test_project",
           "project-path": "/Users/edgedb/test"
         },


### PR DESCRIPTION
The obvious way to implement tests that involve the file system is to put the relevant directory structure and files in a temporary directory. This complicates naming the project directories in `~/.config/edgedb/projects/` because the name of these directories includes a hash of the user's project directory, but the fully qualified project directory name is not known until the test suite creates a temporary directory and prepends it to the project path listed in this file. To facilitate setting these hashes correctly they were replaced with a token `${HASH}` that the test suite can replace with the correct hash when the fully ualified paths are known.

- change `~/.config/edgedb/projects/*` entries in `fs.files` from string to `{"instance-name": "test_project", "project-path": "/home/edgedb/test"}`. This allows calculating a correct project path hash after prepending a temporary directory to the `project-path` value.
- replace project path hash in `.config/edgedb/projects/*` directory names with a place holder
- use real certificate data