### PR TITLE
Change error type for conflicting EDGEDB_DATABASE & EDGEDB_BRANCH

### DIFF
--- a/connection_testcases.json
+++ b/connection_testcases.json
@@ -4397,7 +4397,7 @@
     },
     "fs": {},
     "error": {
-      "type": "exclusive_options"
+      "type": "multiple_compound_env"
     }
   },
   {


### PR DESCRIPTION
It seems like the error type for mutually exclusive environment variables should be `multiple_compound_env`.