### PR TITLE
Remove EDGEDB_USER and EDGEDB_PASSWORD from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Environment variables present at the time of connecting. Possible values:
 | ----------------------------- | --------------------------------------------------- |
 | `EDGEDB_HOST`                 | same as `host` above                                |
 | `EDGEDB_PORT`                 | same as `port` above                                |
-| `EDGEDB_USER`                 | same as `user` above                                |
-| `EDGEDB_PASSWORD`             | same as `password` above                            |
 | `EDGEDB_SECRET_KEY`           | same as `secretKey` above                           |
 | `EDGEDB_DATABASE`             | same as `database` above                            |
 | `EDGEDB_BRANCH`               | same as `branch` above                              |


### PR DESCRIPTION
This is more of a question than a proposed change. I noticed that `EDGEDB_USER` is not in a single test, but is mentioned as a supported environment variable. Are we supposed to support it?

`EDGEDB_PASSWORD` is mentioned in the tests, but it is always either ignored in the result or it is the DSN option `password_env` target like in this test: https://github.com/edgedb/shared-client-testcases/blob/e395996f14b6a2bfed7f8e08676a73414895c93d/tests/override/other.jsonc#L1602-L1616

There are no tests that assert that `EDGEDB_PASSWORD` is recognized by the client on its own. Are there any cases when `EDGEDB_PASSWORD` should be recognized by the client without the `password_env` DSN option?

My knee jerk assumption is that they should both be supported, but I'm not sure I remember all the rules and I'm not sure they are written down anywhere.